### PR TITLE
Added messagebox to clear things up

### DIFF
--- a/R5R-Downloader/Form1.cs
+++ b/R5R-Downloader/Form1.cs
@@ -209,6 +209,10 @@ namespace R5R_Downloader
             }
             else
             {
+                if(e.Stats.BytesDownloaded + e.Stats.BytesDownloadedPrevSession == torrent.data.totalSize)
+                {
+                    MessageBox.Show("Successfully downloaded.");
+                }
                 downRate.Text = String.Format("{0:n0}", (e.Stats.DownRate / 1024)) + " KB/s";
                 downRateAvg.Text = String.Format("{0:n0}", (e.Stats.AvgRate / 1024)) + " KB/s";
                 eta.Text = TimeSpan.FromSeconds((e.Stats.ETA + e.Stats.AvgETA) / 2).ToString(@"hh\:mm\:ss");


### PR DESCRIPTION
Since most of the time the download gets stuck at 99% even though it downloaded everything; I added a check:
`if(e.Stats.BytesDownloaded + e.Stats.BytesDownloadedPrevSession == torrent.data.totalSize)`
so it shows a messagebox that it has downloaded even if progressbar is stuck at 99%
